### PR TITLE
Add Database.TigerBeetle.Client

### DIFF
--- a/src/Database/TigerBeetle/Client.hs
+++ b/src/Database/TigerBeetle/Client.hs
@@ -1,0 +1,36 @@
+module Database.TigerBeetle.Client
+  ( -- ^ Types
+    Client (..)
+  , ClientError (..)
+  , ClientState (..)
+  )
+where
+
+import Control.Exception
+import Control.Monad.Except
+import Control.Monad.State
+import Control.Monad.Trans.Resource
+
+data ClientState
+  = ClientState
+  { completionContextCounter :: Int
+  }
+  deriving (Eq, Show)
+
+data ClientError = ClientError
+  deriving (Eq, Show)
+
+instance Exception ClientError
+
+newtype Client m e a
+  = Client
+  { runClient :: ResourceT (ExceptT ClientError (StateT ClientState m)) a
+  }
+  deriving ( Applicative
+           , Functor
+           , Monad
+           , MonadError ClientError
+           , MonadIO
+           , MonadResource
+           , MonadState ClientState
+           )

--- a/tigerbeetle-hs.cabal
+++ b/tigerbeetle-hs.cabal
@@ -60,7 +60,9 @@ common defaults
 
 library
   import:           defaults
-  exposed-modules:  Database.TigerBeetle
+  exposed-modules:
+    Database.TigerBeetle
+    Database.TigerBeetle.Client
 
   -- Modules included in this library but not exported.
   other-modules:
@@ -73,6 +75,7 @@ library
 
   -- LANGUAGE extensions used by modules in this package.
   default-extensions:
+    GeneralizedNewtypeDeriving
     ImportQualifiedPost
     OverloadedRecordDot
 
@@ -80,6 +83,8 @@ library
   build-depends:
     , base          ^>=4.18.0.0
     , bytestring
+    , mtl
+    , resourcet
     , stm
     , text
     , wide-word     ==0.1.6.0


### PR DESCRIPTION
Added:
  - Client, the top-level monad

This monad uses ResourceT at the top-level to handle calls into the FFI and the exceptions that may throw.

ExceptT is used for user logic errors that may be caught by the library.

StateT is used for managing the state of client requests and forwarding async responses.