### PR TITLE
feat(ffi): Improve enum marshalling

### DIFF
--- a/src/Database/TigerBeetle/Internal/FFI/Account.hsc
+++ b/src/Database/TigerBeetle/Internal/FFI/Account.hsc
@@ -14,10 +14,12 @@ import Foreign.Ptr
 import Foreign.Storable
 import Data.Vector (Vector)
 import Data.Vector qualified as V
+import Data.Set (Set)
+import Database.TigerBeetle.Internal.FFI.BitFlag (flagsToBitmask, bitmaskToFlags)
 
 #include "tb_client.h"
 
-data AccountFlags = 
+data TBAccountFlags = 
       Linked
     | DebitsMustNotExceedCredits
     | CreditsMustNotExceedDebits
@@ -26,7 +28,7 @@ data AccountFlags =
     | Closed
     deriving (Eq, Ord, Show)
 
-instance Enum AccountFlags where
+instance Enum TBAccountFlags where
     fromEnum Linked                     = #const TB_ACCOUNT_LINKED
     fromEnum DebitsMustNotExceedCredits = #const TB_ACCOUNT_DEBITS_MUST_NOT_EXCEED_CREDITS
     fromEnum CreditsMustNotExceedDebits = #const TB_ACCOUNT_CREDITS_MUST_NOT_EXCEED_DEBITS
@@ -42,6 +44,12 @@ instance Enum AccountFlags where
     toEnum (#const TB_ACCOUNT_CLOSED)                          = Closed
     toEnum unmatched = error $ "AccountFlags.toEnum: Cannot match " ++ show unmatched
 
+marshallTBAccountFlags :: Set TBAccountFlags -> Word16 
+marshallTBAccountFlags = flagsToBitmask
+
+unmarshallTBAccountFlags :: Word16 -> Set TBAccountFlags 
+unmarshallTBAccountFlags = bitmaskToFlags
+
 data TBAccount
   = TBAccount
   { tbAccountId             :: Word128
@@ -55,7 +63,7 @@ data TBAccount
   , tbAccountReserved       :: Word32
   , tbAccountLedger         :: Word32
   , tbAccountCode           :: Word16
-  , tbAccountFlags          :: Word16
+  , tbAccountFlags          :: Set TBAccountFlags
   , tbAccountTimestamp      :: Word64
   }
   deriving (Eq, Show)
@@ -77,7 +85,7 @@ instance Storable TBAccount where
       tbAccountReserved       <- #{peek tb_account_t, reserved} ptr
       tbAccountLedger         <- #{peek tb_account_t, ledger} ptr
       tbAccountCode           <- #{peek tb_account_t, code} ptr
-      tbAccountFlags          <- #{peek tb_account_t, flags} ptr
+      tbAccountFlags          <- unmarshallTBAccountFlags <$> #{peek tb_account_t, flags} ptr
       tbAccountTimestamp      <- #{peek tb_account_t, timestamp} ptr
       pure TBAccount{..}
 
@@ -93,10 +101,10 @@ instance Storable TBAccount where
         #{poke tb_account_t, reserved} ptr account.tbAccountReserved
         #{poke tb_account_t, ledger} ptr account.tbAccountLedger
         #{poke tb_account_t, code} ptr account.tbAccountCode
-        #{poke tb_account_t, flags} ptr account.tbAccountFlags
+        #{poke tb_account_t, flags} ptr (marshallTBAccountFlags account.tbAccountFlags)
         #{poke tb_account_t, timestamp} ptr account.tbAccountTimestamp
 
-data CreateAccountResult = 
+data TBCreateAccountResult = 
       Ok
     | LinkedEventFailed
     | LinkedEventChainOpen
@@ -124,9 +132,9 @@ data CreateAccountResult =
     | LedgerMustNotBeZero
     | CodeMustNotBeZero
     | ImportedEventTimestampMustNotRegress
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
-instance Enum CreateAccountResult where
+instance Enum TBCreateAccountResult where
     fromEnum Ok                                   = #const TB_CREATE_ACCOUNT_OK
     fromEnum LinkedEventFailed                    = #const TB_CREATE_ACCOUNT_LINKED_EVENT_FAILED
     fromEnum LinkedEventChainOpen                 = #const TB_CREATE_ACCOUNT_LINKED_EVENT_CHAIN_OPEN
@@ -184,9 +192,15 @@ instance Enum CreateAccountResult where
     toEnum (#const TB_CREATE_ACCOUNT_IMPORTED_EVENT_TIMESTAMP_MUST_NOT_REGRESS) = ImportedEventTimestampMustNotRegress
     toEnum unmatched                                                            = error $ "CreateAccountsResult.toEnum: Cannot match " ++ show unmatched
 
+marshallTBCreateAccountResult :: TBCreateAccountResult -> Word32 
+marshallTBCreateAccountResult = fromIntegral . fromEnum
+
+unmarshallTBCreateAccountResult :: Word32 -> TBCreateAccountResult 
+unmarshallTBCreateAccountResult = toEnum . fromIntegral
+
 data TBCreateAccountsResult = TBCreateAccountsResult
     { tbCreateAccountsResultIndex :: Word32
-    , tbCreateAccountsResultResult :: CreateAccountResult
+    , tbCreateAccountsResultResult :: TBCreateAccountResult
     }
     deriving (Show, Eq)
 
@@ -197,20 +211,20 @@ instance Storable TBCreateAccountsResult  where
 
     peek ptr = do
       tbCreateAccountsResultIndex  <- #{peek tb_create_accounts_result_t, index} ptr
-      tbCreateAccountsResultResult <- toEnum <$> #{peek tb_create_accounts_result_t, result} ptr
+      tbCreateAccountsResultResult <- unmarshallTBCreateAccountResult <$> #{peek tb_create_accounts_result_t, result} ptr
       pure TBCreateAccountsResult{..}
 
     poke ptr createAccountsResult = do
         #{poke tb_create_accounts_result_t, index} ptr createAccountsResult.tbCreateAccountsResultIndex
-        #{poke tb_create_accounts_result_t, result} ptr (fromEnum createAccountsResult.tbCreateAccountsResultResult)
+        #{poke tb_create_accounts_result_t, result} ptr (marshallTBCreateAccountResult $ createAccountsResult.tbCreateAccountsResultResult)
 
-data AccountFilterFlags =
+data TBAccountFilterFlags =
       Debits
     | Credits
     | Reversed
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
-instance Enum AccountFilterFlags where
+instance Enum TBAccountFilterFlags where
     fromEnum Debits   = #const TB_ACCOUNT_FILTER_DEBITS
     fromEnum Credits  = #const TB_ACCOUNT_FILTER_CREDITS
     fromEnum Reversed = #const TB_ACCOUNT_FILTER_REVERSED
@@ -220,6 +234,11 @@ instance Enum AccountFilterFlags where
     toEnum (#const TB_ACCOUNT_FILTER_REVERSED) = Reversed 
     toEnum unmatched                           = error $ "AccountFilterFlags.toEnum: Cannot match " ++ show unmatched
 
+marshallTBAccountFilterFlags :: Set TBAccountFilterFlags -> Word32 
+marshallTBAccountFilterFlags = flagsToBitmask
+
+unmarshallTBAccountFilterFlags :: Word32 -> Set TBAccountFilterFlags 
+unmarshallTBAccountFilterFlags = bitmaskToFlags
 
 data TBAccountFilter = TBAccountFilter
     { tbAccountFilterAccountId :: Word128
@@ -231,7 +250,7 @@ data TBAccountFilter = TBAccountFilter
     , tbAccountFilterTimestampMin :: Word64
     , tbAccountFilterTimestampMax :: Word64
     , tbAccountFilterLimit :: Word32
-    , tbAccountFilterFlags :: Word32
+    , tbAccountFilterFlags :: Set TBAccountFilterFlags
     }
     deriving (Eq, Show)
 
@@ -251,7 +270,7 @@ instance Storable TBAccountFilter where
       tbAccountFilterTimestampMin <- #{peek tb_account_filter_t, timestamp_min} ptr
       tbAccountFilterTimestampMax <- #{peek tb_account_filter_t, timestamp_max} ptr
       tbAccountFilterLimit <- #{peek tb_account_filter_t, limit} ptr
-      tbAccountFilterFlags <- #{peek tb_account_filter_t, flags} ptr
+      tbAccountFilterFlags <- unmarshallTBAccountFilterFlags <$> #{peek tb_account_filter_t, flags} ptr
       pure TBAccountFilter{..}
 
     poke ptr accountFilter = do
@@ -263,7 +282,7 @@ instance Storable TBAccountFilter where
       #{poke tb_account_filter_t, timestamp_min} ptr accountFilter.tbAccountFilterTimestampMin
       #{poke tb_account_filter_t, timestamp_max} ptr accountFilter.tbAccountFilterTimestampMax
       #{poke tb_account_filter_t, limit} ptr accountFilter.tbAccountFilterLimit
-      #{poke tb_account_filter_t, flags} ptr accountFilter.tbAccountFilterFlags
+      #{poke tb_account_filter_t, flags} ptr (marshallTBAccountFilterFlags accountFilter.tbAccountFilterFlags)
       let reservedPtr = #{ptr tb_account_filter_t, reserved} ptr
       V.iforM_ accountFilter.tbAccountFilterReserved (pokeByteOff reservedPtr)
 

--- a/src/Database/TigerBeetle/Internal/FFI/BitFlag.hs
+++ b/src/Database/TigerBeetle/Internal/FFI/BitFlag.hs
@@ -5,7 +5,7 @@ import Data.Set qualified as S
 import Data.Set (Set)
 import Data.Bits
 
-flagsToBitmask :: (Enum a, FiniteBits b, Num b) => Set a -> b
+flagsToBitmask :: forall a b. (Enum a, FiniteBits b, Num b) => Set a -> b
 flagsToBitmask = S.foldr (\flag acc -> acc .|. fromIntegral (fromEnum flag)) 0
 
 safeFlagsToBitmask :: forall a b. (Bounded a, Enum a, FiniteBits b, Num b) => Set a -> Maybe b
@@ -16,7 +16,7 @@ safeFlagsToBitmask s =
     then Just $ flagsToBitmask s
     else Nothing
 
-bitmaskToFlags :: forall a b. (Ord a, Enum a, FiniteBits b, Num b) => b -> Set a
+bitmaskToFlags :: forall b a. (Ord a, Enum a, FiniteBits b, Num b) => b -> Set a
 bitmaskToFlags bitmask = S.fromList $ 
   [ flag | flag <- enumFrom (toEnum 0)
   -- Note: an alternate implementation could look like this, which makes the C style
@@ -27,7 +27,7 @@ bitmaskToFlags bitmask = S.fromList $
   ]
 
 safeBitmaskToFlags
-  :: forall a b
+  :: forall b a
   . (Ord a, Bounded a, Enum a, FiniteBits b, Num b)
   => b
   -> Maybe (Set a)

--- a/src/Database/TigerBeetle/Internal/FFI/BitFlag.hs
+++ b/src/Database/TigerBeetle/Internal/FFI/BitFlag.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TypeApplications #-}
+module Database.TigerBeetle.Internal.FFI.BitFlag where
+
+import Data.Set qualified as S
+import Data.Set (Set)
+import Data.Bits
+
+flagsToBitmask :: (Enum a, FiniteBits b, Num b) => Set a -> b
+flagsToBitmask = S.foldr (\flag acc -> acc .|. fromIntegral (fromEnum flag)) 0
+
+safeFlagsToBitmask :: forall a b. (Bounded a, Enum a, FiniteBits b, Num b) => Set a -> Maybe b
+safeFlagsToBitmask s =
+  let enoughBitsForFlags = S.size s <= finiteBitSize @b 0
+      wordIsBigEnough = fromEnum (maxBound @a) <= 2 ^ finiteBitSize @b 0
+  in if enoughBitsForFlags && wordIsBigEnough
+    then Just $ flagsToBitmask s
+    else Nothing
+
+bitmaskToFlags :: forall a b. (Ord a, Enum a, FiniteBits b, Num b) => b -> Set a
+bitmaskToFlags bitmask = S.fromList $ 
+  [ flag | flag <- enumFrom (toEnum 0)
+  -- Note: an alternate implementation could look like this, which makes the C style
+  -- bit flag more obvious
+  --
+  -- (bitmask .&. fromIntegral @Int @b (fromEnum flag)) /= 0
+  , testBit bitmask . countTrailingZeros . fromIntegral @Int @b $ fromEnum flag
+  ]
+
+safeBitmaskToFlags
+  :: forall a b
+  . (Ord a, Bounded a, Enum a, FiniteBits b, Num b)
+  => b
+  -> Maybe (Set a)
+safeBitmaskToFlags bitmask = if fromEnum (maxBound @a) <= 2 ^ finiteBitSize @b 0
+  then Just $ bitmaskToFlags bitmask
+  else Nothing

--- a/src/Database/TigerBeetle/Internal/FFI/Client.hsc
+++ b/src/Database/TigerBeetle/Internal/FFI/Client.hsc
@@ -117,6 +117,12 @@ instance Enum TBOperation where
     toEnum (#const TB_OPERATION_GET_EVENTS)            = GetEvents
     toEnum unmatched = error $ "TBOperation.toEnum: Cannot match " ++ show unmatched
 
+marshallTBOperation :: TBOperation -> Word8 
+marshallTBOperation = fromIntegral . fromEnum
+
+unmarshallTBOperation :: Word8 -> TBOperation 
+unmarshallTBOperation = toEnum . fromIntegral
+
 data TBPacketStatus =
       Ok
     | TooMuchData
@@ -148,6 +154,12 @@ instance Enum TBPacketStatus where
     toEnum (#const TB_PACKET_INVALID_DATA_SIZE)       = InvalidDataSize
     toEnum unmatched = error $ "TBPacketStatus.toEnum: Cannot match " ++ show unmatched
 
+marshallTBPacketStatus :: TBPacketStatus -> Word8 
+marshallTBPacketStatus = fromIntegral . fromEnum
+
+unmarshallTBPacketStatus :: Word8 -> TBPacketStatus 
+unmarshallTBPacketStatus = toEnum . fromIntegral
+
 data TBPacket = TBPacket
     { tbPacketUserData   :: Ptr ()
     , tbPacketData       :: Ptr ()
@@ -169,8 +181,8 @@ instance Storable TBPacket where
       tbPacketData       <- #{peek tb_packet_t, data} ptr
       tbPacketDataSize   <- #{peek tb_packet_t, data_size} ptr
       tbPacketUserTag    <- #{peek tb_packet_t, user_tag} ptr
-      tbPacketOperation  <- toEnum <$> #{peek tb_packet_t, operation} ptr
-      tbPacketStatus     <- toEnum <$> #{peek tb_packet_t, status} ptr
+      tbPacketOperation  <- unmarshallTBOperation <$> #{peek tb_packet_t, operation} ptr
+      tbPacketStatus     <- unmarshallTBPacketStatus <$> #{peek tb_packet_t, status} ptr
       let opaquePtr = #{ptr tb_packet_t, opaque} ptr
       tbPacketOpaque     <- V.generateM 32 (\i -> peekByteOff opaquePtr i)
       pure TBPacket{..}
@@ -180,8 +192,8 @@ instance Storable TBPacket where
         #{poke tb_packet_t, data} ptr packet.tbPacketData
         #{poke tb_packet_t, data_size} ptr packet.tbPacketDataSize
         #{poke tb_packet_t, user_tag} ptr packet.tbPacketUserTag
-        #{poke tb_packet_t, operation} ptr (fromEnum packet.tbPacketOperation)
-        #{poke tb_packet_t, status} ptr (fromEnum packet.tbPacketStatus)
+        #{poke tb_packet_t, operation} ptr (marshallTBOperation packet.tbPacketOperation)
+        #{poke tb_packet_t, status} ptr (marshallTBPacketStatus packet.tbPacketStatus)
         let opaquePtr = #{ptr tb_packet_t, opaque} ptr
         V.iforM_ packet.tbPacketOpaque $ \i val -> pokeByteOff opaquePtr i val
 

--- a/src/Database/TigerBeetle/Internal/FFI/Query.hsc
+++ b/src/Database/TigerBeetle/Internal/FFI/Query.hsc
@@ -12,20 +12,28 @@ import Data.Word
 import Data.WideWord
 import Foreign.Ptr
 import Foreign.Storable
+import Data.Set (Set)
 import Data.Vector (Vector)
 import Data.Vector qualified as V
+import Database.TigerBeetle.Internal.FFI.BitFlag (flagsToBitmask, bitmaskToFlags)
 
 #include "tb_client.h"
 
-data QueryFilterFlags = 
+data TBQueryFilterFlags = 
       Reversed
     deriving (Eq, Ord, Show)
 
-instance Enum QueryFilterFlags where
+instance Enum TBQueryFilterFlags where
     fromEnum Reversed = #const TB_QUERY_FILTER_REVERSED
 
     toEnum (#const TB_QUERY_FILTER_REVERSED) = Reversed
     toEnum unmatched = error $ "QueryFilterFlags.toEnum: Cannot match " ++ show unmatched
+
+marshallTBQueryFilterFlags :: Set TBQueryFilterFlags -> Word32 
+marshallTBQueryFilterFlags = flagsToBitmask
+
+unmarshallTBQueryFilterFlags :: Word32 -> Set TBQueryFilterFlags 
+unmarshallTBQueryFilterFlags = bitmaskToFlags
 
 data TBQueryFilter = TBQueryFilter
     { tbQueryFilterUserData128   :: Word128
@@ -37,7 +45,7 @@ data TBQueryFilter = TBQueryFilter
     , tbQueryFilterTimestampMin  :: Word64
     , tbQueryFilterTimestampMax  :: Word64
     , tbQueryFilterLimit         :: Word32
-    , tbQueryFilterFlags         :: Word32
+    , tbQueryFilterFlags         :: Set TBQueryFilterFlags
     }
     deriving (Show, Eq)
 
@@ -57,7 +65,7 @@ instance Storable TBQueryFilter where
       tbQueryFilterTimestampMin  <- #{peek tb_query_filter_t, timestamp_min} ptr
       tbQueryFilterTimestampMax  <- #{peek tb_query_filter_t, timestamp_max} ptr
       tbQueryFilterLimit         <- #{peek tb_query_filter_t, limit} ptr
-      tbQueryFilterFlags         <- #{peek tb_query_filter_t, flags} ptr
+      tbQueryFilterFlags         <- unmarshallTBQueryFilterFlags <$> #{peek tb_query_filter_t, flags} ptr
       pure TBQueryFilter{..}
 
     poke ptr queryFilter = do
@@ -71,4 +79,4 @@ instance Storable TBQueryFilter where
         #{poke tb_query_filter_t, timestamp_min} ptr queryFilter.tbQueryFilterTimestampMin
         #{poke tb_query_filter_t, timestamp_max} ptr queryFilter.tbQueryFilterTimestampMax
         #{poke tb_query_filter_t, limit} ptr queryFilter.tbQueryFilterLimit
-        #{poke tb_query_filter_t, flags} ptr queryFilter.tbQueryFilterFlags
+        #{poke tb_query_filter_t, flags} ptr (marshallTBQueryFilterFlags queryFilter.tbQueryFilterFlags)

--- a/src/Database/TigerBeetle/Internal/FFI/Transfer.hsc
+++ b/src/Database/TigerBeetle/Internal/FFI/Transfer.hsc
@@ -10,11 +10,13 @@ module Database.TigerBeetle.Internal.FFI.Transfer where
 
 import Data.Word
 import Data.WideWord
+import Data.Set (Set)
 import Foreign.Storable
+import Database.TigerBeetle.Internal.FFI.BitFlag (flagsToBitmask, bitmaskToFlags)
 
 #include "tb_client.h"
 
-data TransferFlags = 
+data TBTransferFlags = 
       Linked 
     | Pending 
     | PostPendingTransfer 
@@ -24,9 +26,9 @@ data TransferFlags =
     | ClosingDebit 
     | ClosingCredit 
     | Imported 
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
-instance Enum TransferFlags where
+instance Enum TBTransferFlags where
     fromEnum Linked              = #const TB_TRANSFER_LINKED
     fromEnum Pending             = #const TB_TRANSFER_PENDING
     fromEnum PostPendingTransfer = #const TB_TRANSFER_POST_PENDING_TRANSFER
@@ -48,6 +50,12 @@ instance Enum TransferFlags where
     toEnum (#const TB_TRANSFER_IMPORTED) = Imported
     toEnum unmatched = error $ "TransferFlags.toEnum: Cannot match " ++ show unmatched
 
+marshallTBTransferFlags :: Set TBTransferFlags -> Word16 
+marshallTBTransferFlags = flagsToBitmask
+
+unmarshallTBTransferFlags :: Word16 -> Set TBTransferFlags 
+unmarshallTBTransferFlags = bitmaskToFlags
+
 data TBTransfer
   = TBTransfer
   { tbTransferId :: Word128
@@ -61,7 +69,7 @@ data TBTransfer
   , tbTransferTimeout :: Word32
   , tbTransferLedger :: Word32
   , tbTransferCode :: Word16
-  , tbTransferFlags :: Word16
+  , tbTransferFlags :: Set TBTransferFlags
   , tbTransferTimestamp :: Word64
   }
   deriving (Eq, Show)
@@ -71,21 +79,21 @@ instance Storable TBTransfer where
 
     alignment _ = #{alignment tb_transfer_t}
 
-    peek ptr
-      = TBTransfer
-        <$> #{peek tb_transfer_t, id} ptr
-        <*> #{peek tb_transfer_t, debit_account_id} ptr
-        <*> #{peek tb_transfer_t, credit_account_id} ptr
-        <*> #{peek tb_transfer_t, amount} ptr
-        <*> #{peek tb_transfer_t, pending_id} ptr
-        <*> #{peek tb_transfer_t, user_data_128} ptr
-        <*> #{peek tb_transfer_t, user_data_64} ptr
-        <*> #{peek tb_transfer_t, user_data_32} ptr
-        <*> #{peek tb_transfer_t, timeout} ptr
-        <*> #{peek tb_transfer_t, ledger} ptr
-        <*> #{peek tb_transfer_t, code} ptr
-        <*> #{peek tb_transfer_t, flags} ptr
-        <*> #{peek tb_transfer_t, timestamp} ptr
+    peek ptr = do
+        tbTransferId <- #{peek tb_transfer_t, id} ptr
+        tbTransferDebitAccountId <- #{peek tb_transfer_t, debit_account_id} ptr
+        tbTransferCreditAccountId <- #{peek tb_transfer_t, credit_account_id} ptr
+        tbTransferAmount <- #{peek tb_transfer_t, amount} ptr
+        tbTransferPendingId <- #{peek tb_transfer_t, pending_id} ptr
+        tbTransferUserData128 <- #{peek tb_transfer_t, user_data_128} ptr
+        tbTransferUserData64 <- #{peek tb_transfer_t, user_data_64} ptr
+        tbTransferUserData32 <- #{peek tb_transfer_t, user_data_32} ptr
+        tbTransferTimeout <- #{peek tb_transfer_t, timeout} ptr
+        tbTransferLedger <- #{peek tb_transfer_t, ledger} ptr
+        tbTransferCode <- #{peek tb_transfer_t, code} ptr
+        tbTransferFlags <- unmarshallTBTransferFlags <$> #{peek tb_transfer_t, flags} ptr
+        tbTransferTimestamp <- #{peek tb_transfer_t, timestamp} ptr
+        pure TBTransfer{..}
 
     poke ptr transfer = do
         #{poke tb_transfer_t, id} ptr transfer.tbTransferId
@@ -99,11 +107,10 @@ instance Storable TBTransfer where
         #{poke tb_transfer_t, timeout} ptr transfer.tbTransferTimeout
         #{poke tb_transfer_t, ledger} ptr transfer.tbTransferLedger
         #{poke tb_transfer_t, code} ptr transfer.tbTransferCode
-        #{poke tb_transfer_t, flags} ptr transfer.tbTransferFlags
+        #{poke tb_transfer_t, flags} ptr (marshallTBTransferFlags transfer.tbTransferFlags)
         #{poke tb_transfer_t, timestamp} ptr transfer.tbTransferTimestamp
 
-
-data CreateTransferResult =
+data TBCreateTransferResult =
       Ok 
     | LinkedEventFailed 
     | LinkedEventChainOpen 
@@ -174,7 +181,7 @@ data CreateTransferResult =
     | ExceedsDebits 
     deriving (Show, Eq)
 
-instance Enum CreateTransferResult where
+instance Enum TBCreateTransferResult where
     fromEnum Ok                                              = #const TB_CREATE_TRANSFER_OK
     fromEnum LinkedEventFailed                               = #const TB_CREATE_TRANSFER_LINKED_EVENT_FAILED
     fromEnum LinkedEventChainOpen                            = #const TB_CREATE_TRANSFER_LINKED_EVENT_CHAIN_OPEN
@@ -314,9 +321,15 @@ instance Enum CreateTransferResult where
     toEnum (#const TB_CREATE_TRANSFER_EXCEEDS_DEBITS)                                        = ExceedsDebits
     toEnum unmatched                                                                         = error $ "CreateTransfersResult.toEnum: Cannot match " ++ show unmatched
 
+marshallTBCreateTransferResult :: TBCreateTransferResult -> Word32 
+marshallTBCreateTransferResult = fromIntegral . fromEnum
+
+unmarshallTBCreateTransferResult :: Word32 -> TBCreateTransferResult 
+unmarshallTBCreateTransferResult = toEnum . fromIntegral
+
 data TBCreateTransfersResult = TBCreateTransfersResult
     { tbCreateTransfersResultIndex :: Word32
-    , tbCreateTransfersResultResult :: CreateTransferResult
+    , tbCreateTransfersResultResult :: TBCreateTransferResult
     }
     deriving (Show, Eq)
 
@@ -327,9 +340,9 @@ instance Storable TBCreateTransfersResult  where
 
     peek ptr = do
       tbCreateTransfersResultIndex  <- #{peek tb_create_transfers_result_t, index} ptr
-      tbCreateTransfersResultResult <- toEnum <$> #{peek tb_create_transfers_result_t, result} ptr
+      tbCreateTransfersResultResult <- unmarshallTBCreateTransferResult <$> #{peek tb_create_transfers_result_t, result} ptr
       pure TBCreateTransfersResult{..}
 
     poke ptr createTransfersResult = do
         #{poke tb_create_transfers_result_t, index} ptr createTransfersResult.tbCreateTransfersResultIndex
-        #{poke tb_create_transfers_result_t, result} ptr (fromEnum createTransfersResult.tbCreateTransfersResultResult)
+        #{poke tb_create_transfers_result_t, result} ptr (marshallTBCreateTransferResult createTransfersResult.tbCreateTransfersResultResult)

--- a/tigerbeetle-hs.cabal
+++ b/tigerbeetle-hs.cabal
@@ -72,6 +72,7 @@ library
     Database.TigerBeetle.Internal.FFI.Query
     Database.TigerBeetle.Internal.FFI.Client
     Database.TigerBeetle.Internal.FFI.Client.ClusterId
+    Database.TigerBeetle.Internal.FFI.BitFlag
     Database.TigerBeetle.Raw.Account
     Database.TigerBeetle.Raw.Client
     Database.TigerBeetle.Raw.Queue
@@ -81,11 +82,13 @@ library
     GeneralizedNewtypeDeriving
     ImportQualifiedPost
     OverloadedRecordDot
+    ScopedTypeVariables
 
   -- Other library packages from which modules are imported.
   build-depends:
     , base          ^>=4.18.0.0
     , bytestring
+    , containers
     , mtl
     , resourcet
     , stm


### PR DESCRIPTION
These improvements come in two forms:
- The first is properly using the bitmask flags to unmarshall a set of flags (haskell sum type). Additionally we re-create the bitmask when marshalling back to C
- Separating out dedicated marshalling and unmarshalling functions (instead of inlining them in the Storable instances). This accomplishes two goals: consistency, makes the type signatures explicit. This helps make the connection between the C types, that are marshalling to and from, explicit.

One theoretical issue for the bitmask words is if an enum type is encoded as different size words in different structs, then our marshalling / unmarshalling functions would become a burden (with their explicit word sizes in haskell). However this did not prove to be a problem in the current TB client.