### PR TITLE
Modify Raw/Client.hs

### DIFF
--- a/src/Database/TigerBeetle/Internal/FFI/Client.hsc
+++ b/src/Database/TigerBeetle/Internal/FFI/Client.hsc
@@ -9,6 +9,7 @@
 module Database.TigerBeetle.Internal.FFI.Client where
 
 import Data.Word
+import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.C.String
@@ -117,10 +118,10 @@ instance Enum TBOperation where
     toEnum (#const TB_OPERATION_GET_EVENTS)            = GetEvents
     toEnum unmatched = error $ "TBOperation.toEnum: Cannot match " ++ show unmatched
 
-marshallTBOperation :: TBOperation -> Word8 
+marshallTBOperation :: TBOperation -> Word8
 marshallTBOperation = fromIntegral . fromEnum
 
-unmarshallTBOperation :: Word8 -> TBOperation 
+unmarshallTBOperation :: Word8 -> TBOperation
 unmarshallTBOperation = toEnum . fromIntegral
 
 data TBPacketStatus =
@@ -154,10 +155,10 @@ instance Enum TBPacketStatus where
     toEnum (#const TB_PACKET_INVALID_DATA_SIZE)       = InvalidDataSize
     toEnum unmatched = error $ "TBPacketStatus.toEnum: Cannot match " ++ show unmatched
 
-marshallTBPacketStatus :: TBPacketStatus -> Word8 
+marshallTBPacketStatus :: TBPacketStatus -> Word8
 marshallTBPacketStatus = fromIntegral . fromEnum
 
-unmarshallTBPacketStatus :: Word8 -> TBPacketStatus 
+unmarshallTBPacketStatus :: Word8 -> TBPacketStatus
 unmarshallTBPacketStatus = toEnum . fromIntegral
 
 data TBPacket = TBPacket
@@ -199,9 +200,9 @@ instance Storable TBPacket where
 
 type TBCompletionContext = CUIntPtr
 
--- TODO: add comments explaining what these represent, asked a question in TB slack 
+-- TODO: add comments explaining what these represent, asked a question in TB slack
 type TBCompletionCallback =
-  TBCompletionContext -> 
+  TBCompletionContext ->
   Ptr TBPacket ->
   Word64 ->
   Ptr Word8 ->
@@ -217,8 +218,8 @@ foreign import ccall "tb_client.h tb_client_init"
       -> Ptr Word8
       -> CString
       -> Word32
-      -> CUIntPtr 
-      -> FunPtr TBCompletionCallback 
+      -> CUIntPtr
+      -> FunPtr TBCompletionCallback
       -> IO Word32
 
 tbClientInit
@@ -239,8 +240,8 @@ foreign import ccall "tb_client.h tb_client_init_echo"
       -> Ptr Word8
       -> CString
       -> Word32
-      -> TBCompletionContext 
-      -> FunPtr TBCompletionCallback  
+      -> TBCompletionContext
+      -> FunPtr TBCompletionCallback
       -> IO Word32
 
 tbClientInitEcho
@@ -272,6 +273,12 @@ tbClientSubmit client packet = toEnum . fromIntegral <$> c_tb_client_submit clie
 
 foreign import ccall "tb_client.h tb_client_deinit"
     c_tb_client_deinit :: Ptr TBClient -> IO Word32
+
+type TBClientFinalizerCallback
+  = Ptr TBClient -> IO ()
+
+foreign import ccall "wrapper"
+    makeClientFinalizer :: TBClientFinalizerCallback -> IO (FunPtr TBClientFinalizerCallback)
 
 tbClientDeinit :: Ptr TBClient -> IO TBClientStatus
 tbClientDeinit client = toEnum . fromIntegral <$> c_tb_client_deinit client

--- a/src/Database/TigerBeetle/Raw/Client.hs
+++ b/src/Database/TigerBeetle/Raw/Client.hs
@@ -93,8 +93,8 @@ newtype ClientHandle = ClientHandle { tvar :: TVar ClientState }
 data Address = Address { getAddress :: Text }
   deriving (Eq, Show)
 
-toCString :: Address -> ((Ptr CChar, Int) -> IO a) -> IO a
-toCString = BS.useAsCStringLen . TE.encodeUtf8 . getAddress
+withAddressPtr :: Address -> ((Ptr CChar, Int) -> IO a) -> IO a
+withAddressPtr = BS.useAsCStringLen . TE.encodeUtf8 . getAddress
 
 data ClientInitError
   = Unexpected
@@ -154,7 +154,7 @@ initClientEcho
 initClientEcho clusterId address completionCtx completionCallback = do
   clientPtr <- initClientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
-    toCString address $ \(addrPtr, addrLen) -> do
+    withAddressPtr address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInitEcho
         cp
         clusterId
@@ -176,7 +176,7 @@ initClient
 initClient clusterId address completionCtx completionCallback = do
   clientPtr <- initClientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
-    toCString address $ \(addrPtr, addrLen) -> do
+    withAddressPtr address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInit
         cp
         clusterId

--- a/src/Database/TigerBeetle/Raw/Client.hs
+++ b/src/Database/TigerBeetle/Raw/Client.hs
@@ -5,12 +5,23 @@
 module Database.TigerBeetle.Raw.Client where
 
 import Database.TigerBeetle.Internal.FFI.Client
+  ( TBClient
+  , TBClientStatus (..)
+  , TBCompletionContext
+  , TBCompletionCallback
+  , TBInitStatus
+  , TBOperation (..)
+  , TBPacket (..)
+  , TBPacketStatus (..)
+  )
+import Database.TigerBeetle.Internal.FFI.Client qualified as FFI
 import Database.TigerBeetle.Internal.FFI.Client.ClusterId (ClusterId)
 import Data.Text (Text)
-import Foreign.Marshal.Alloc (alloca)
+import Foreign.Marshal.Alloc (alloca, malloc)
 import Foreign (Storable (..))
-import Control.Exception (finally)
-import Foreign.Ptr (Ptr, nullPtr, castPtr)
+import Control.Exception (assert, finally)
+import Foreign.Ptr (Ptr, FunPtr, nullPtr, castPtr)
+import Foreign.ForeignPtr
 import GHC.Natural (Natural)
 import Data.Word
 import Control.Concurrent.STM.TMVar (TMVar, putTMVar, newEmptyTMVar, takeTMVar)
@@ -74,6 +85,98 @@ data ClientState = ClientState
 
 newtype ClientHandle = ClientHandle { tvar :: TVar ClientState }
 
+data Address = Address { getAddress :: Text }
+  deriving (Eq, Show)
+
+toCString :: Address -> ((Ptr CChar, Int) -> IO a) -> IO a
+toCString = BS.useAsCStringLen . TE.encodeUtf8 . getAddress
+
+data ClientInitError
+  = Unexpected
+  | OutOfMemory
+  | AddressInvalid
+  | AddressLimitExceeded
+  | SystemResources
+  | NetworkSubsystem
+  deriving (Eq, Show)
+
+-- | Create a 'Client' initialization error from a 'TBInitStatus'.
+--
+-- Asserts that @err@ is not 'FFI.Success', throws an exception at
+-- runtime.
+toClientInitError :: TBInitStatus -> ClientInitError
+toClientInitError err = assert (err /= FFI.Success) $
+  case err of
+    FFI.Unexpected           -> Unexpected
+    FFI.OutOfMemory          -> OutOfMemory
+    FFI.AddressInvalid       -> AddressInvalid
+    FFI.AddressLimitExceeded -> AddressLimitExceeded
+    FFI.SystemResources      -> SystemResources
+    FFI.NetworkSubsystem     -> NetworkSubsystem
+    FFI.Success              -> error "toClientInitError: Success is not an error"
+
+type Client = ForeignPtr FFI.TBClient
+
+clientFinalizer :: Ptr TBClient -> IO ()
+clientFinalizer clientPtr = do
+  result <- FFI.tbClientDeinit clientPtr
+  case result of
+    FFI.ClientOk -> pure ()
+    FFI.ClientInvalid ->
+      error $ "tbClientFinalizer (invalid clientPtr): " ++ show clientPtr
+
+-- | Call @tb_client_init_echo@ and return a valid 'Client' upon success.
+--
+-- The finalizer on 'Client' will call @tb_client_deinit@.
+initClientEcho
+  :: ClusterId
+  -> Address
+  -> TBCompletionContext
+  -> FunPtr TBCompletionCallback
+  -> IO (Either ClientInitError Client)
+initClientEcho clusterId address completionCtx completionCallback = do
+  rawClientPtr <- malloc
+  finalizer <- FFI.makeClientFinalizer clientFinalizer
+  clientPtr <- newForeignPtr finalizer rawClientPtr
+  initStatus <- withForeignPtr clientPtr $ \cp -> do
+    toCString address $ \(addrPtr, addrLen) -> do
+      FFI.tbClientInitEcho
+        cp
+        clusterId
+        addrPtr
+        (fromIntegral addrLen)
+        completionCtx
+        completionCallback
+  case initStatus of
+    FFI.Success -> pure $ Right clientPtr
+    initError   -> pure . Left . toClientInitError $ initError
+
+-- | Call @tb_client_init@ and return a valid 'Client' upon success.
+--
+-- The finalizer on 'Client' will call @tb_client_deinit@.
+initClient
+  :: ClusterId
+  -> Address
+  -> TBCompletionContext
+  -> FunPtr TBCompletionCallback
+  -> IO (Either ClientInitError Client)
+initClient clusterId address completionCtx completionCallback = do
+  rawClientPtr <- malloc
+  finalizer <- FFI.makeClientFinalizer clientFinalizer
+  clientPtr <- newForeignPtr finalizer rawClientPtr
+  initStatus <- withForeignPtr clientPtr $ \cp -> do
+    toCString address $ \(addrPtr, addrLen) -> do
+      FFI.tbClientInit
+        cp
+        clusterId
+        addrPtr
+        (fromIntegral addrLen)
+        completionCtx
+        completionCallback
+  case initStatus of
+    FFI.Success -> pure $ Right clientPtr
+    initError   -> pure . Left . toClientInitError $ initError
+
 -- | Initializes the completion callback
 setupCompletionCallback :: ClientState -> TBCompletionCallback
 setupCompletionCallback state = \ctx packetPtr _timestamp resultPtr resultLen -> do
@@ -129,13 +232,13 @@ withClient cfg clusterId address action =
       <*> pure cfg.clientTimeoutMillis
 
     -- Initialize the completion callback
-    callback <- makeCompletionCallback $ setupCompletionCallback clientState
+    callback <- FFI.makeCompletionCallback $ setupCompletionCallback clientState
 
 
     BS.useAsCStringLen (TE.encodeUtf8 address) $ \(addressPtr, addressLen) -> do
       let initFn = case cfg.clientKind of
-                     Standard -> tbClientInit
-                     Echo -> tbClientInitEcho
+                     Standard -> FFI.tbClientInit
+                     Echo -> FFI.tbClientInitEcho
 
       -- Initialize the client
       initStatus <- initFn
@@ -147,7 +250,7 @@ withClient cfg clusterId address action =
         callback
 
       case initStatus of
-        Success -> finally
+        FFI.Success -> finally
             (Right <$> action clientState)
             (finalizeClient clientState)
         _ -> pure $ Left initStatus
@@ -177,7 +280,7 @@ finalizeClient state = do
       putTMVar context.resultVar (Left ClientShutdownDuringRequest)
 
   -- De-initialize the client
-  void $ tbClientDeinit state.csClientPtr
+  void $ FFI.tbClientDeinit state.csClientPtr
 
 submitRequest
   :: ClientState
@@ -207,7 +310,7 @@ submitRequest state operation reqData = do
       poke packetPtr packet
 
       -- Submit the request
-      submitStatus <- tbClientSubmit state.csClientPtr packetPtr
+      submitStatus <- FFI.tbClientSubmit state.csClientPtr packetPtr
 
       case submitStatus of
         ClientOk -> do

--- a/src/Database/TigerBeetle/Raw/Client.hs
+++ b/src/Database/TigerBeetle/Raw/Client.hs
@@ -17,11 +17,16 @@ import Database.TigerBeetle.Internal.FFI.Client
 import Database.TigerBeetle.Internal.FFI.Client qualified as FFI
 import Database.TigerBeetle.Internal.FFI.Client.ClusterId (ClusterId)
 import Data.Text (Text)
-import Foreign.Marshal.Alloc (alloca, malloc)
+import Foreign.Marshal.Alloc (alloca)
 import Foreign (Storable (..))
 import Control.Exception (assert, finally)
 import Foreign.Ptr (Ptr, FunPtr, nullPtr, castPtr)
 import Foreign.ForeignPtr
+  ( ForeignPtr
+  , addForeignPtrFinalizer
+  , mallocForeignPtr
+  , withForeignPtr
+  )
 import GHC.Natural (Natural)
 import Data.Word
 import Control.Concurrent.STM.TMVar (TMVar, putTMVar, newEmptyTMVar, takeTMVar)
@@ -135,9 +140,9 @@ initClientEcho
   -> FunPtr TBCompletionCallback
   -> IO (Either ClientInitError Client)
 initClientEcho clusterId address completionCtx completionCallback = do
-  rawClientPtr <- malloc
   finalizer <- FFI.makeClientFinalizer clientFinalizer
-  clientPtr <- newForeignPtr finalizer rawClientPtr
+  clientPtr <- mallocForeignPtr
+  addForeignPtrFinalizer finalizer clientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
     toCString address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInitEcho
@@ -161,9 +166,9 @@ initClient
   -> FunPtr TBCompletionCallback
   -> IO (Either ClientInitError Client)
 initClient clusterId address completionCtx completionCallback = do
-  rawClientPtr <- malloc
   finalizer <- FFI.makeClientFinalizer clientFinalizer
-  clientPtr <- newForeignPtr finalizer rawClientPtr
+  clientPtr <- mallocForeignPtr
+  addForeignPtrFinalizer finalizer clientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
     toCString address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInit

--- a/src/Database/TigerBeetle/Raw/Client.hs
+++ b/src/Database/TigerBeetle/Raw/Client.hs
@@ -130,6 +130,18 @@ clientFinalizer clientPtr = do
     FFI.ClientInvalid ->
       error $ "tbClientFinalizer (invalid clientPtr): " ++ show clientPtr
 
+initClientPtr :: IO (ForeignPtr TBClient)
+initClientPtr = do
+  finalizer <- FFI.makeClientFinalizer clientFinalizer
+  clientPtr <- mallocForeignPtr
+  addForeignPtrFinalizer finalizer clientPtr
+  pure clientPtr
+
+validateClientInit :: Client -> TBInitStatus -> IO (Either ClientInitError Client)
+validateClientInit clientPtr = \case
+  FFI.Success -> pure $ Right clientPtr
+  initError   -> pure . Left . toClientInitError $ initError
+
 -- | Call @tb_client_init_echo@ and return a valid 'Client' upon success.
 --
 -- The finalizer on 'Client' will call @tb_client_deinit@.
@@ -140,9 +152,7 @@ initClientEcho
   -> FunPtr TBCompletionCallback
   -> IO (Either ClientInitError Client)
 initClientEcho clusterId address completionCtx completionCallback = do
-  finalizer <- FFI.makeClientFinalizer clientFinalizer
-  clientPtr <- mallocForeignPtr
-  addForeignPtrFinalizer finalizer clientPtr
+  clientPtr <- initClientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
     toCString address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInitEcho
@@ -152,9 +162,7 @@ initClientEcho clusterId address completionCtx completionCallback = do
         (fromIntegral addrLen)
         completionCtx
         completionCallback
-  case initStatus of
-    FFI.Success -> pure $ Right clientPtr
-    initError   -> pure . Left . toClientInitError $ initError
+  validateClientInit clientPtr initStatus
 
 -- | Call @tb_client_init@ and return a valid 'Client' upon success.
 --
@@ -166,9 +174,7 @@ initClient
   -> FunPtr TBCompletionCallback
   -> IO (Either ClientInitError Client)
 initClient clusterId address completionCtx completionCallback = do
-  finalizer <- FFI.makeClientFinalizer clientFinalizer
-  clientPtr <- mallocForeignPtr
-  addForeignPtrFinalizer finalizer clientPtr
+  clientPtr <- initClientPtr
   initStatus <- withForeignPtr clientPtr $ \cp -> do
     toCString address $ \(addrPtr, addrLen) -> do
       FFI.tbClientInit
@@ -178,9 +184,7 @@ initClient clusterId address completionCtx completionCallback = do
         (fromIntegral addrLen)
         completionCtx
         completionCallback
-  case initStatus of
-    FFI.Success -> pure $ Right clientPtr
-    initError   -> pure . Left . toClientInitError $ initError
+  validateClientInit clientPtr initStatus
 
 -- | Initializes the completion callback
 setupCompletionCallback :: ClientState -> TBCompletionCallback


### PR DESCRIPTION
The comments in `tb_client.h` for the `tb_client_t` struct say that the memory for this struct must remain "pinned." This means the address of this struct must remain stable throughout the lifetime of the request.

A `ForeignPtr` represents references managed by a foreign language -- in this case, `tb_client`. The pointer seems to be managed by `tb_client` as the documentation of `tb_client_deinit` implies that the library uses the struct to de-allocate internal data it is managing.

This change is the first in a series to refactor `withClient` to use the `ForeignPtr` reference. It is also the beginning of a larger refactor to decompose `withClient` and associated functions so that the `Raw` module's scope can be limited to calling into the FFI modules and client functionality can be implemented at a higher level with safer APIs and structures.

Added:
  - ClientInitError
  - Client
  - initClient
  - initClientEcho

Also updated Internal/FFI/Client.hsc.

Added:
  - TBClientFinalizerCallback
  - makeClientFinalizer